### PR TITLE
Add a GitHub Actions Badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js CI
+name: CI
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@
 name: Node.js CI
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # angular-practice
 
+![Actions Status](https://github.com/noranuko13/angular-practice/workflows/CI/badge.svg)
+
 ## Overview
 
 - Practice of Programming Angular.


### PR DESCRIPTION
### Overview

- CI of the main branch after merging.
- View Actions Status badge.

### Reference

- GitHub Actions - GitHub Support Community
  - [Trigger workflow only on pull request MERGE](https://github.community/t/trigger-workflow-only-on-pull-request-merge/17359)
